### PR TITLE
[CS-125][CS-126] Send Localization and Unique Identification for sensors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+hardware/nodemcu-esp8266/iot_configs.h

--- a/hardware/nodemcu-esp8266/iot_configs.h
+++ b/hardware/nodemcu-esp8266/iot_configs.h
@@ -10,5 +10,5 @@
 #define IOT_CONFIG_DEVICE_ID "nodemcu"
 #define IOT_CONFIG_DEVICE_KEY ""
 
-// Publish 1 message every 30 seconds
-#define TELEMETRY_FREQUENCY_MILLISECS 30000
+// Publish 1 message every 15 seconds
+#define TELEMETRY_FREQUENCY_MILLISECS 15000

--- a/hardware/nodemcu-esp8266/nodemcu-esp8266.ino
+++ b/hardware/nodemcu-esp8266/nodemcu-esp8266.ino
@@ -327,7 +327,8 @@ static char* getTelemetryPayload()
   int distance;
   //Ultrasonic 1
   distance = ultrasonic1.read();
-  temp_span = az_span_copy(temp_span, AZ_SPAN_FROM_STR("{\"type\": "));
+  temp_span = az_span_copy(temp_span, AZ_SPAN_FROM_STR("{\"uid\": \"0001\""));
+  temp_span = az_span_copy(temp_span, AZ_SPAN_FROM_STR(", \"type\": "));
   (void)az_span_u32toa(temp_span, SENSOR_TYPE, &temp_span);
   temp_span = az_span_copy(temp_span, AZ_SPAN_FROM_STR(", \"data\": "));
   (void)az_span_u32toa(temp_span, (uint32_t) distance, &temp_span);
@@ -335,7 +336,8 @@ static char* getTelemetryPayload()
 
   //Ultrasonic 2
   distance = ultrasonic2.read();
-  temp_span = az_span_copy(temp_span, AZ_SPAN_FROM_STR("{\"type\": "));
+  temp_span = az_span_copy(temp_span, AZ_SPAN_FROM_STR("{\"uid\": \"0002\""));
+  temp_span = az_span_copy(temp_span, AZ_SPAN_FROM_STR(", \"type\": "));
   (void)az_span_u32toa(temp_span, SENSOR_TYPE, &temp_span);
   temp_span = az_span_copy(temp_span, AZ_SPAN_FROM_STR(", \"data\": "));
   (void)az_span_u32toa(temp_span, (uint32_t) distance, &temp_span);

--- a/hardware/nodemcu-esp8266/nodemcu-esp8266.ino
+++ b/hardware/nodemcu-esp8266/nodemcu-esp8266.ino
@@ -80,7 +80,7 @@ static unsigned char encrypted_signature[32];
 static char base64_decoded_device_key[32];
 static unsigned long next_telemetry_send_time_ms = 0;
 static char telemetry_topic[128];
-static uint8_t telemetry_payload[100];
+static uint8_t telemetry_payload[200];
 static uint32_t telemetry_send_count = 0;
 
 //Example Package
@@ -320,6 +320,8 @@ static char* getTelemetryPayload()
   az_span temp_span = az_span_create(telemetry_payload, sizeof(telemetry_payload));
   temp_span = az_span_copy(temp_span, AZ_SPAN_FROM_STR("{ \"sensor_quantity\": "));
   (void)az_span_u32toa(temp_span, SENSOR_QUANTITY, &temp_span);
+  temp_span = az_span_copy(temp_span, AZ_SPAN_FROM_STR(", \"sensor_latitude\": \"-8.017797\""));
+  temp_span = az_span_copy(temp_span, AZ_SPAN_FROM_STR(", \"sensor_longitude\": \"-34.944716\""));
   temp_span = az_span_copy(temp_span, AZ_SPAN_FROM_STR(", \"sensor_data\": [ "));
 
   int distance;


### PR DESCRIPTION
This PR addresses the tasks to obtain localization data (such as latitude and logitude), and also implements UID for each sensor in a gateway.

## Implementation

It implements the following static parameters in the request:

- `sensor_latitude`
- `sensor_longitude`
- `uid` for each sensor

I've also increased the payload request size between nodemcu to Azure IoT (from 100 bytes to 200 bytes).

## How to test it

Send a GET request to our preview endpoint in `https://cata-sucata.azure-api.net/preview/status-preview?type=raw`; it is necessary to configure a parameter `type` set to `raw`, as previously configured. You may see a response similar to the following:

```json
{
    "sensor_quantity": 2,
    "sensor_latitude": "-8.017797",
    "sensor_longitude": "-34.944716",
    "sensor_data": [
        {
            "uid": "0001",
            "type": 1,
            "data": 4
        },
        {
            "uid": "0002",
            "type": 1,
            "data": 12
        }
    ]
}
```