### PR TITLE
[CS-139] Controladores  CRUD da Área de Coleta

### DIFF
--- a/backend/functions/create-areacoleta/function.json
+++ b/backend/functions/create-areacoleta/function.json
@@ -1,0 +1,19 @@
+{
+    "scriptFile": "main.py",
+    "bindings": [
+        {
+            "authLevel": "function",
+            "type": "httpTrigger",
+            "direction": "in",
+            "name": "req",
+            "methods": [
+                "post"
+            ]
+        },
+        {
+            "type": "http",
+            "direction": "out",
+            "name": "$return"
+        }
+    ]
+}

--- a/backend/functions/create-areacoleta/main.py
+++ b/backend/functions/create-areacoleta/main.py
@@ -1,0 +1,20 @@
+import logging
+import json
+
+import azure.functions as func
+
+from shared_code.area_coleta import AreaColeta
+
+def main(req: func.HttpRequest) -> func.HttpResponse:
+    body = req.get_json()
+    area = AreaColeta(
+        nome=body['nome'],
+        coords=(body['latitude'], body['longitude']),
+        tamanho=body['tamanho']
+    )
+    area.insert()
+    return func.HttpResponse(
+        body=json.dumps(body),
+        mimetype='application/json',
+        status_code=200
+    )

--- a/backend/functions/delete-areacoleta/function.json
+++ b/backend/functions/delete-areacoleta/function.json
@@ -1,0 +1,19 @@
+{
+    "scriptFile": "main.py",
+    "bindings": [
+        {
+            "authLevel": "function",
+            "type": "httpTrigger",
+            "direction": "in",
+            "name": "req",
+            "methods": [
+                "delete"
+            ]
+        },
+        {
+            "type": "http",
+            "direction": "out",
+            "name": "$return"
+        }
+    ]
+}

--- a/backend/functions/delete-areacoleta/main.py
+++ b/backend/functions/delete-areacoleta/main.py
@@ -1,0 +1,14 @@
+import json
+
+import azure.functions as func
+
+from shared_code.area_coleta import AreaColeta
+
+def main(req: func.HttpRequest) -> func.HttpResponse:
+    body = req.get_json()
+    AreaColeta.remove(body['id'], body['name'])
+    return func.HttpResponse(
+        body=json.dumps(body),
+        mimetype='application/json',
+        status_code=200
+    )

--- a/backend/functions/get-areacoleta/function.json
+++ b/backend/functions/get-areacoleta/function.json
@@ -1,0 +1,19 @@
+{
+    "scriptFile": "main.py",
+    "bindings": [
+        {
+            "authLevel": "function",
+            "type": "httpTrigger",
+            "direction": "in",
+            "name": "req",
+            "methods": [
+                "get"
+            ]
+        },
+        {
+            "type": "http",
+            "direction": "out",
+            "name": "$return"
+        }
+    ]
+}

--- a/backend/functions/get-areacoleta/main.py
+++ b/backend/functions/get-areacoleta/main.py
@@ -1,0 +1,16 @@
+import json
+
+import azure.functions as func
+
+from shared_code.area_coleta import AreaColeta
+
+def main(req: func.HttpRequest) -> func.HttpResponse:
+    id = req.params.get('id')
+    name = req.params.get('name')
+
+    item = AreaColeta.get_item(id,name)
+    return func.HttpResponse(
+        body=json.dumps(item),
+        mimetype='application/json',
+        status_code=200
+    )

--- a/backend/functions/list-areacoleta/function.json
+++ b/backend/functions/list-areacoleta/function.json
@@ -1,0 +1,19 @@
+{
+    "scriptFile": "main.py",
+    "bindings": [
+        {
+            "authLevel": "function",
+            "type": "httpTrigger",
+            "direction": "in",
+            "name": "req",
+            "methods": [
+                "get"
+            ]
+        },
+        {
+            "type": "http",
+            "direction": "out",
+            "name": "$return"
+        }
+    ]
+}

--- a/backend/functions/list-areacoleta/main.py
+++ b/backend/functions/list-areacoleta/main.py
@@ -1,0 +1,13 @@
+import json
+
+import azure.functions as func
+
+from shared_code.area_coleta import AreaColeta
+
+def main(req: func.HttpRequest) -> func.HttpResponse:
+    items = AreaColeta.list_all()
+    return func.HttpResponse(
+        body=json.dumps(items),
+        mimetype='application/json',
+        status_code=200
+    )

--- a/backend/functions/shared_code/area_coleta.py
+++ b/backend/functions/shared_code/area_coleta.py
@@ -17,3 +17,14 @@ class AreaColeta(object):
         self.latitude = coords[0]
         self.longitude = coords[1]
         self.tamanho = tamanho
+
+    def insert(self):
+        """Insere a área de coleta no banco de dados Azure.
+        """
+        item = {
+            'nome': self.nome,
+            'latitude': str(self.latitude),
+            'longitude': str(self.longitude),
+            'tamanho': self.tamanho
+        }
+        container.create_item(item, enable_automatic_id_generation=True)

--- a/backend/functions/shared_code/area_coleta.py
+++ b/backend/functions/shared_code/area_coleta.py
@@ -1,0 +1,19 @@
+import os
+from azure.cosmos import CosmosClient
+
+COSMOS_DB_CONNECTION_STR = os.environ['COSMOS_DB_CONNECTION_STR']
+client = CosmosClient.from_connection_string(COSMOS_DB_CONNECTION_STR)
+COSMOS_DB_DATABASE_ID = 'SensorData'
+database = client.get_database_client(COSMOS_DB_DATABASE_ID)
+COSMOS_DB_CONTAINER_ID = 'areacoleta'
+container = database.get_container_client(COSMOS_DB_CONTAINER_ID)
+
+class AreaColeta(object):
+    """
+    Objeto que representa uma área de coleta de lixo.
+    """
+    def __init__(self, nome: str, coords: tuple, tamanho: str) -> None:
+        self.nome = nome
+        self.latitude = coords[0]
+        self.longitude = coords[1]
+        self.tamanho = tamanho

--- a/backend/functions/shared_code/area_coleta.py
+++ b/backend/functions/shared_code/area_coleta.py
@@ -1,5 +1,7 @@
+import json
 import os
 from azure.cosmos import CosmosClient
+
 
 COSMOS_DB_CONNECTION_STR = os.environ['COSMOS_DB_CONNECTION_STR']
 client = CosmosClient.from_connection_string(COSMOS_DB_CONNECTION_STR)
@@ -8,11 +10,13 @@ database = client.get_database_client(COSMOS_DB_DATABASE_ID)
 COSMOS_DB_CONTAINER_ID = 'areacoleta'
 container = database.get_container_client(COSMOS_DB_CONTAINER_ID)
 
+
 class AreaColeta(object):
     """
     Objeto que representa uma área de coleta de lixo.
     """
     def __init__(self, nome: str, coords: tuple, tamanho: str) -> None:
+        self.id = None
         self.nome = nome
         self.latitude = coords[0]
         self.longitude = coords[1]
@@ -28,3 +32,18 @@ class AreaColeta(object):
             'tamanho': self.tamanho
         }
         container.create_item(item, enable_automatic_id_generation=True)
+    
+    @staticmethod
+    def list_all() -> list[str, str]:
+        QUERY = "SELECT c.id, c.nome, c.latitude, c.longitude, c.tamanho FROM c"
+        results = container.query_items(QUERY, enable_cross_partition_query=True)
+        return [item for item in results]
+
+    @staticmethod
+    def get_item(id: str, name: str):
+        return container.read_item(item=id, partition_key=name)
+
+
+    @staticmethod
+    def remove(id: str, name: str):
+        container.delete_item(item=id, partition_key=name)


### PR DESCRIPTION
Esta Pull Request visa implementar os métodos de interface para a área de coleta. A área de coleta se trata de uma localização geográfica no sistema e deve ser especificada com os atributos: Nome, Localização Geográfica (Latitude e Longitude) e tamanho. 

Closes CS-139

## Implementação

Cria novos métodos na API do cata-sucata para ter acesso a entidade de Área de Coleta, são os seguintes métodos:

### Create - POST

Método POST para `/create-areacoleta` com o seguinte body:

```json
{
  "nome": "Torre",
  "latitude": "-8.00937",
  "longitude": "-34.8553",
  "tamanho": "14"
}
```

O **nome** da área de coleta é `Torre`, com **latitude** e **longitude** de `-8.00937` e `-34.8553` respectivamente, e tamanho de `14` km².

### Read - GET

Método GET para `/get-areacoleta` com os seguintes parâmetros:

```params
id=ea8bf4a6-ec3b-4a63-bff4-40876822419d
name=Torre
```

O `id` corresponde ao identificador gerado para o item criado e o **name** se trata do nome da área de coleta.

### List all - GET

Método GET para `/list-areacoleta`. 

Não há necessidade de parâmetros ou body.

### Remove - DELETE

Método DELETE para `/delete-areacoleta` com o seguinte body:

```json
{
  "id": "ea8bf4a6-ec3b-4a63-bff4-40876822419d",
  "name": "Torre",
}
```

