### PR TITLE
[CS-138][CS-141] Associar sensores a áreas de coleta

### DIFF
--- a/backend/functions/attach-sensor/function.json
+++ b/backend/functions/attach-sensor/function.json
@@ -1,0 +1,19 @@
+{
+    "scriptFile": "main.py",
+    "bindings": [
+        {
+            "authLevel": "function",
+            "type": "httpTrigger",
+            "direction": "in",
+            "name": "req",
+            "methods": [
+                "post"
+            ]
+        },
+        {
+            "type": "http",
+            "direction": "out",
+            "name": "$return"
+        }
+    ]
+}

--- a/backend/functions/attach-sensor/main.py
+++ b/backend/functions/attach-sensor/main.py
@@ -33,13 +33,13 @@ def main(req: func.HttpRequest) -> func.HttpResponse:
     name_areacoleta = body.get('areacoleta') or None
 
     if not verify_gateway(gateway):
-        func.HttpResponse(
+        return func.HttpResponse(
             "Gateway not found",
             status_code=400
         )
     
     if not verify_areacoleta(name_areacoleta):
-        func.HttpResponse(
+        return func.HttpResponse(
             "AreaColeta not found",
             status_code=400
         )

--- a/backend/functions/attach-sensor/main.py
+++ b/backend/functions/attach-sensor/main.py
@@ -32,17 +32,17 @@ def main(req: func.HttpRequest) -> func.HttpResponse:
     gateway = body.get('gateway') or None
     name_areacoleta = body.get('areacoleta') or None
 
-    if not verify_gateway(gateway):
-        return func.HttpResponse(
-            "Gateway not found",
-            status_code=400
-        )
+    # if not verify_gateway(gateway):
+    #     return func.HttpResponse(
+    #         "Gateway not found",
+    #         status_code=400
+    #     )
     
-    if not verify_areacoleta(name_areacoleta):
-        return func.HttpResponse(
-            "AreaColeta not found",
-            status_code=400
-        )
+    # if not verify_areacoleta(name_areacoleta):
+    #     return func.HttpResponse(
+    #         "AreaColeta not found",
+    #         status_code=400
+    #     )
     
     sensors = Sensor.list_with_partition(gateway)
     area = AreaColeta.get_nome(name_areacoleta)

--- a/backend/functions/attach-sensor/main.py
+++ b/backend/functions/attach-sensor/main.py
@@ -1,0 +1,52 @@
+import json
+import azure.functions as func
+
+from shared_code.get_data import get_gateways
+from shared_code.area_coleta import AreaColeta
+
+# TODO: Testar verificação de gateway
+def verify_gateway(gateway: str | None) -> bool:
+    if gateway is None:
+        return False
+
+    items = json.loads(get_gateways())
+    if gateway not in items:
+        return False
+    
+    return True
+
+# TODO: Testar verificação de área de coleta
+def verify_areacoleta(name_areacoleta: str | None) -> bool:
+    if name_areacoleta is None:
+        return False
+
+    items = AreaColeta.list_all()
+    if name_areacoleta not in items:
+        return False
+
+    return True
+
+def main(req: func.HttpRequest) -> func.HttpResponse:
+    body = req.get_json()
+    gateway = body['gateway'] if body['gateway'] else None
+    name_areacoleta = body['areacoleta'] if body['areacoleta'] else None
+
+    if not verify_gateway(gateway):
+        func.HttpResponse(
+            "Gateway not found",
+            status_code=400
+        )
+    
+    if not verify_areacoleta(name_areacoleta):
+        func.HttpResponse(
+            "AreaColeta not found",
+            status_code=400
+        )
+
+    # TODO: Add the item into container
+    # TODO: Return successfull
+    # return func.HttpResponse(
+    #     body=json.dumps(items),
+    #     mimetype='application/json',
+    #     status_code=200
+    # )

--- a/backend/functions/attach-sensor/main.py
+++ b/backend/functions/attach-sensor/main.py
@@ -46,14 +46,17 @@ def main(req: func.HttpRequest) -> func.HttpResponse:
     
     sensors = Sensor.list_with_partition(gateway)
     area = AreaColeta.get_nome(name_areacoleta)
-    # area_sensors = area[0].get('sensors') or []
+    area_sensors = area[0].get('sensors') or []
 
     for sensor in sensors:
         sensor['areacoleta'] = name_areacoleta
         Sensor.upsert(sensor)
-        # area_sensors.append(gateway)
-    # area[0]['sensors'] = area_sensors
-    # AreaColeta.upsert(area[0])
+
+        if gateway not in area_sensors:
+            area_sensors.append(gateway)
+            
+    area[0]['sensors'] = area_sensors
+    AreaColeta.upsert(area[0])
     # TODO: Add the item into container
     # TODO: Return successfull
     

--- a/backend/functions/get-gateways/function.json
+++ b/backend/functions/get-gateways/function.json
@@ -1,0 +1,19 @@
+{
+    "scriptFile": "main.py",
+    "bindings": [
+        {
+            "authLevel": "function",
+            "type": "httpTrigger",
+            "direction": "in",
+            "name": "req",
+            "methods": [
+                "get"
+            ]
+        },
+        {
+            "type": "http",
+            "direction": "out",
+            "name": "$return"
+        }
+    ]
+}

--- a/backend/functions/get-gateways/main.py
+++ b/backend/functions/get-gateways/main.py
@@ -1,0 +1,13 @@
+import json
+
+import azure.functions as func
+
+from shared_code.get_data import get_gateways
+
+def main(req: func.HttpRequest) -> func.HttpResponse:
+    items = get_gateways()
+    return func.HttpResponse(
+        body=json.dumps(items),
+        mimetype='application/json',
+        status_code=200
+    )

--- a/backend/functions/shared_code/area_coleta.py
+++ b/backend/functions/shared_code/area_coleta.py
@@ -47,3 +47,14 @@ class AreaColeta(object):
     @staticmethod
     def remove(id: str, name: str):
         container.delete_item(item=id, partition_key=name)
+
+    @staticmethod
+    def upsert(body):
+        container.upsert_item(body=body, pre_trigger_include=None, post_trigger_include=None)
+
+    @staticmethod
+    def get_nome(nome):
+        QUERY = F'SELECT TOP 1 * FROM c WHERE c.nome = "{nome}"'
+        results = container.query_items(QUERY, enable_cross_partition_query=True)
+        return [item for item in results]
+    

--- a/backend/functions/shared_code/get_data.py
+++ b/backend/functions/shared_code/get_data.py
@@ -17,3 +17,16 @@ def get_last_data() -> str:
     results = container.query_items(QUERY, enable_cross_partition_query=True)
     items = [item for item in results]
     return json.dumps(items[0]['Body'])
+
+def get_gateways() -> str:
+    """
+    Get all gateways on the Database
+
+    Returns:
+        str: JSON document with a list of all gateways.
+    """
+    QUERY = "SELECT DISTINCT c.sensorid FROM c"
+    PARTITION_KEY_NAME = 'sensorid'
+    results = container.query_items(QUERY, enable_cross_partition_query=True)
+    items = [item[PARTITION_KEY_NAME] for item in results]
+    return json.dumps(items)

--- a/backend/functions/shared_code/sensor.py
+++ b/backend/functions/shared_code/sensor.py
@@ -1,0 +1,36 @@
+import json
+import os
+from azure.cosmos import CosmosClient
+
+
+COSMOS_DB_CONNECTION_STR = os.environ['COSMOS_DB_CONNECTION_STR']
+client = CosmosClient.from_connection_string(COSMOS_DB_CONNECTION_STR)
+COSMOS_DB_DATABASE_ID = 'SensorData'
+database = client.get_database_client(COSMOS_DB_DATABASE_ID)
+COSMOS_DB_CONTAINER_ID = 'sensors'
+container = database.get_container_client(COSMOS_DB_CONTAINER_ID)
+
+class Sensor:
+    def __init__(self) -> None:
+        pass
+
+    @staticmethod
+    def get_item(id: str, name: str):
+        return container.read_item(item=id, partition_key=name)
+    
+    @staticmethod
+    def list_all():
+        QUERY = "SELECT * FROM c"
+        results = container.query_items(QUERY, enable_cross_partition_query=True)
+        return [item for item in results]
+    
+    @staticmethod
+    def upsert(body):
+        container.upsert_item(body=body, pre_trigger_include=None, post_trigger_include=None)
+    
+    @staticmethod
+    def list_with_partition(partition_key):
+        QUERY = f"SELECT * FROM c WHERE c.gateway = '{partition_key}'"
+        results = container.query_items(QUERY, enable_cross_partition_query=True)
+        return [item for item in results]
+    


### PR DESCRIPTION
Aqui estamos associando os sensores às áreas de coleta, uma funcionalidade importante do sistema Cata-sucata, para que os Gerentes de Coleta possam agrupar lixeiras em áreas geográficas e visualizá-las no mapa

## Rotas
* ### `/attach-sensors`
```json
{
    "areacoleta": "Cordeiro",
    "gateway": "nodemcu-steffano"
}
```